### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:

--- a/.github/workflows/SuperLint.yml
+++ b/.github/workflows/SuperLint.yml
@@ -42,7 +42,7 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # Full git history is needed to get a proper list of changed files
           fetch-depth: 0
@@ -52,7 +52,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: super-linter/super-linter@v8
+        uses: super-linter/super-linter@47984f49b4e87383eed97890fe2dca6063bbd9c3 # v8.3.1
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: master

--- a/.github/workflows/SuperLint.yml
+++ b/.github/workflows/SuperLint.yml
@@ -8,20 +8,27 @@ name: Lint Code Base
 
 #
 # Documentation:
-# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
 #
 
 #############################
 # Start the job on all push #
 #############################
 on:
-  push
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+permissions:
+  contents: read
+  statuses: write
 
 ###############
 # Set the Job #
 ###############
 jobs:
-  build:
+  lint:
     # Name the Job
     name: Lint Code Base
     # Set the agent to run on
@@ -35,14 +42,19 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          # Full git history is needed to get a proper list of changed files
+          fetch-depth: 0
+          persist-credentials: false
 
       ################################
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: docker://github/super-linter:v3
+        uses: super-linter/super-linter@v8
         env:
-          VALIDATE_ALL_CODEBASE: true 
+          VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINTER_RULES_PATH: /

--- a/OSQuery-Jupyter-MacOS.ipynb
+++ b/OSQuery-Jupyter-MacOS.ipynb
@@ -76,14 +76,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import json\n",
-    "import subprocess\n",
-    "\n",
-    "import pandas as pd\n",
-    "from IPython.display import display\n",
-    "from pandas.io.json import json_normalize"
-   ]
+   "source": "# pylint: disable=invalid-name,missing-module-docstring\nimport json\nimport subprocess\n\nimport pandas as pd\nfrom IPython.display import display\nfrom pandas.io.json import json_normalize"
   },
   {
    "cell_type": "markdown",
@@ -134,17 +127,7 @@
     ]
    },
    "outputs": [],
-   "source": [
-    "commands = [\n",
-    "    'osqueryi --logger_min_status 1 --json \"select bundle_identifier, bundle_short_version  from apps ORDER BY name;\"'\n",
-    "]\n",
-    "for command in commands:\n",
-    "    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n",
-    "    nested = json.loads(data)\n",
-    "    df = pd.DataFrame(json_normalize(nested)).head(50)\n",
-    "    df.style.set_properties(**{\"text-align\": \"right\"})\n",
-    "    display(df.style.hide_index())"
-   ]
+   "source": "commands = [\n    'osqueryi --logger_min_status 1 --json '\n    '\"select bundle_identifier, bundle_short_version from apps ORDER BY name;\"'\n]\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested)).head(50)\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
   },
   {
    "cell_type": "markdown",
@@ -165,15 +148,7 @@
     ]
    },
    "outputs": [],
-   "source": [
-    "commands = ['osqueryi --logger_min_status 1 --json \"select * from logged_in_users;\"']\n",
-    "for command in commands:\n",
-    "    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n",
-    "    nested = json.loads(data)\n",
-    "    df = pd.DataFrame(json_normalize(nested))\n",
-    "    df.style.set_properties(**{\"text-align\": \"right\"})\n",
-    "    display(df.style.hide_index())"
-   ]
+   "source": "commands = [\n    'osqueryi --logger_min_status 1 --json '\n    '\"select * from logged_in_users;\"'\n]\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested))\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
   },
   {
    "cell_type": "markdown",
@@ -219,17 +194,7 @@
     ]
    },
    "outputs": [],
-   "source": [
-    "commands = [\n",
-    "    'osqueryi --logger_min_status 1 --json \"SELECT network_name, security_type FROM wifi_networks;\"'\n",
-    "]\n",
-    "for command in commands:\n",
-    "    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n",
-    "    nested = json.loads(data)\n",
-    "    df = pd.DataFrame(json_normalize(nested)).head(50)\n",
-    "    df.style.set_properties(**{\"text-align\": \"right\"})\n",
-    "    display(df.style.hide_index())"
-   ]
+   "source": "commands = [\n    'osqueryi --logger_min_status 1 --json '\n    '\"SELECT network_name, security_type FROM wifi_networks;\"'\n]\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested)).head(50)\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
   },
   {
    "cell_type": "markdown",

--- a/OSQuery-Jupyter-MacOS.ipynb
+++ b/OSQuery-Jupyter-MacOS.ipynb
@@ -148,7 +148,7 @@
     ]
    },
    "outputs": [],
-   "source": "# pylint: disable=line-too-long\ncommands = [\n    'osqueryi --logger_min_status 1 --json \"select * from logged_in_users;\"'\n]\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested))\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
+   "source": "# pylint: disable=line-too-long\ncommands = ['osqueryi --logger_min_status 1 --json \"select * from logged_in_users;\"']\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested))\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
   },
   {
    "cell_type": "markdown",

--- a/OSQuery-Jupyter-MacOS.ipynb
+++ b/OSQuery-Jupyter-MacOS.ipynb
@@ -127,7 +127,7 @@
     ]
    },
    "outputs": [],
-   "source": "commands = [\n    (\n        'osqueryi --logger_min_status 1 --json '\n        '\"select bundle_identifier, bundle_short_version '\n        'from apps ORDER BY name;\"'\n    )\n]\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested)).head(50)\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
+   "source": "query = (\n    \"select bundle_identifier, bundle_short_version \"\n    \"from apps ORDER BY name;\"\n)\ncommands = [f'osqueryi --logger_min_status 1 --json \"{query}\"']\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested)).head(50)\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
   },
   {
    "cell_type": "markdown",
@@ -148,7 +148,7 @@
     ]
    },
    "outputs": [],
-   "source": "commands = [\n    (\n        'osqueryi --logger_min_status 1 --json '\n        '\"select * from logged_in_users;\"'\n    )\n]\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested))\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
+   "source": "query = \"select * from logged_in_users;\"\ncommands = [f'osqueryi --logger_min_status 1 --json \"{query}\"']\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested))\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
   },
   {
    "cell_type": "markdown",
@@ -194,7 +194,7 @@
     ]
    },
    "outputs": [],
-   "source": "commands = [\n    (\n        'osqueryi --logger_min_status 1 --json '\n        '\"SELECT network_name, security_type FROM wifi_networks;\"'\n    )\n]\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested)).head(50)\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
+   "source": "query = \"SELECT network_name, security_type FROM wifi_networks;\"\ncommands = [f'osqueryi --logger_min_status 1 --json \"{query}\"']\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested)).head(50)\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
   },
   {
    "cell_type": "markdown",

--- a/OSQuery-Jupyter-MacOS.ipynb
+++ b/OSQuery-Jupyter-MacOS.ipynb
@@ -77,12 +77,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
     "import json\n",
     "import subprocess\n",
+    "\n",
     "import pandas as pd\n",
-    "from pandas.io.json import json_normalize\n",
-    "from IPython.display import JSON,display,HTML"
+    "from IPython.display import display\n",
+    "from pandas.io.json import json_normalize"
    ]
   },
   {
@@ -108,10 +108,10 @@
    "source": [
     "commands = ['osqueryi --logger_min_status 1 --json \"select * from os_version\"']\n",
     "for command in commands:\n",
-    "    data = subprocess.check_output(commands, shell=True).decode('utf-8')\n",
+    "    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n",
     "    nested = json.loads(data)\n",
     "    df = pd.DataFrame(json_normalize(nested))\n",
-    "    df.style.set_properties(**{'text-align': 'right'})\n",
+    "    df.style.set_properties(**{\"text-align\": \"right\"})\n",
     "    display(df.style.hide_index())"
    ]
   },
@@ -135,12 +135,14 @@
    },
    "outputs": [],
    "source": [
-    "commands = ['osqueryi --logger_min_status 1 --json \"select bundle_identifier, bundle_short_version  from apps ORDER BY name;\"']\n",
+    "commands = [\n",
+    "    'osqueryi --logger_min_status 1 --json \"select bundle_identifier, bundle_short_version  from apps ORDER BY name;\"'\n",
+    "]\n",
     "for command in commands:\n",
-    "    data = subprocess.check_output(commands, shell=True).decode('utf-8')\n",
+    "    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n",
     "    nested = json.loads(data)\n",
     "    df = pd.DataFrame(json_normalize(nested)).head(50)\n",
-    "    df.style.set_properties(**{'text-align': 'right'})\n",
+    "    df.style.set_properties(**{\"text-align\": \"right\"})\n",
     "    display(df.style.hide_index())"
    ]
   },
@@ -166,10 +168,10 @@
    "source": [
     "commands = ['osqueryi --logger_min_status 1 --json \"select * from logged_in_users;\"']\n",
     "for command in commands:\n",
-    "    data = subprocess.check_output(commands, shell=True).decode('utf-8')\n",
+    "    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n",
     "    nested = json.loads(data)\n",
     "    df = pd.DataFrame(json_normalize(nested))\n",
-    "    df.style.set_properties(**{'text-align': 'right'})\n",
+    "    df.style.set_properties(**{\"text-align\": \"right\"})\n",
     "    display(df.style.hide_index())"
    ]
   },
@@ -191,10 +193,10 @@
    "source": [
     "commands = ['osqueryi --logger_min_status 1 --json \"select * from last\"']\n",
     "for command in commands:\n",
-    "    data = subprocess.check_output(commands, shell=True).decode('utf-8')\n",
+    "    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n",
     "    nested = json.loads(data)\n",
     "    df = pd.DataFrame(json_normalize(nested)).head(10)\n",
-    "    df.style.set_properties(**{'text-align': 'right'})\n",
+    "    df.style.set_properties(**{\"text-align\": \"right\"})\n",
     "    display(df.style.hide_index())"
    ]
   },
@@ -218,12 +220,14 @@
    },
    "outputs": [],
    "source": [
-    "commands = ['osqueryi --logger_min_status 1 --json \"SELECT network_name, security_type FROM wifi_networks;\"']\n",
+    "commands = [\n",
+    "    'osqueryi --logger_min_status 1 --json \"SELECT network_name, security_type FROM wifi_networks;\"'\n",
+    "]\n",
     "for command in commands:\n",
-    "    data = subprocess.check_output(commands, shell=True).decode('utf-8')\n",
+    "    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n",
     "    nested = json.loads(data)\n",
     "    df = pd.DataFrame(json_normalize(nested)).head(50)\n",
-    "    df.style.set_properties(**{'text-align': 'right'})\n",
+    "    df.style.set_properties(**{\"text-align\": \"right\"})\n",
     "    display(df.style.hide_index())"
    ]
   },
@@ -245,10 +249,10 @@
    "source": [
     "commands = ['osqueryi --logger_min_status 1 --json \"SELECT * FROM uptime;\"']\n",
     "for command in commands:\n",
-    "    data = subprocess.check_output(commands, shell=True).decode('utf-8')\n",
+    "    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n",
     "    nested = json.loads(data)\n",
     "    df = pd.DataFrame(json_normalize(nested))\n",
-    "    df.style.set_properties(**{'text-align': 'right'})\n",
+    "    df.style.set_properties(**{\"text-align\": \"right\"})\n",
     "    display(df.style.hide_index())"
    ]
   },
@@ -268,13 +272,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "commands = ['osqueryi --logger_min_status 1 --json \"SELECT a.interface, a.address, d.mac FROM interface_addresses a JOIN interface_details d USING (interface);\"']\n",
+    "commands = [\n",
+    "    'osqueryi --logger_min_status 1 --json \"SELECT a.interface, a.address, d.mac FROM interface_addresses a JOIN interface_details d USING (interface);\"'\n",
+    "]\n",
     "for command in commands:\n",
-    "    data = subprocess.check_output(commands, shell=True).decode('utf-8')\n",
+    "    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n",
     "    nested = json.loads(data)\n",
     "    df = pd.DataFrame(json_normalize(nested))\n",
-    "    df.style.set_properties(**{'text-align': 'right'})\n",
-    "    display(df.style.hide_index().set_properties(**{'text-align': 'left'}))"
+    "    df.style.set_properties(**{\"text-align\": \"right\"})\n",
+    "    display(df.style.hide_index().set_properties(**{\"text-align\": \"left\"}))"
    ]
   },
   {
@@ -294,11 +300,11 @@
    "source": [
     "commands = ['osqueryi --logger_min_status 1 --json \"SELECT * FROM homebrew_packages;\"']\n",
     "for command in commands:\n",
-    "    data = subprocess.check_output(commands, shell=True).decode('utf-8')\n",
+    "    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n",
     "    nested = json.loads(data)\n",
     "    df = pd.DataFrame(json_normalize(nested)).head(50)\n",
-    "    df.style.set_properties(**{'text-align': 'right'})\n",
-    "    display(df.style.hide_index().set_properties(**{'text-align': 'left'}))"
+    "    df.style.set_properties(**{\"text-align\": \"right\"})\n",
+    "    display(df.style.hide_index().set_properties(**{\"text-align\": \"left\"}))"
    ]
   },
   {
@@ -317,13 +323,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "commands = ['osqueryi --logger_min_status 1 --json \"SELECT device, device_alias, path, type, blocks_size FROM mounts;\"']\n",
+    "commands = [\n",
+    "    'osqueryi --logger_min_status 1 --json \"SELECT device, device_alias, path, type, blocks_size FROM mounts;\"'\n",
+    "]\n",
     "for command in commands:\n",
-    "    data = subprocess.check_output(commands, shell=True).decode('utf-8')\n",
+    "    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n",
     "    nested = json.loads(data)\n",
     "    df = pd.DataFrame(json_normalize(nested))\n",
-    "    df.style.set_properties(**{'text-align': 'right'})\n",
-    "    display(df.style.hide_index().set_properties(**{'text-align': 'left'}))"
+    "    df.style.set_properties(**{\"text-align\": \"right\"})\n",
+    "    display(df.style.hide_index().set_properties(**{\"text-align\": \"left\"}))"
    ]
   },
   {
@@ -344,11 +352,11 @@
    "source": [
     "commands = ['osqueryi --logger_min_status 1 --json \"SELECT * FROM startup_items;\"']\n",
     "for command in commands:\n",
-    "    data = subprocess.check_output(commands, shell=True).decode('utf-8')\n",
+    "    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n",
     "    nested = json.loads(data)\n",
     "    df = pd.DataFrame(json_normalize(nested))\n",
-    "    df.style.set_properties(**{'text-align': 'right'})\n",
-    "    display(df.style.hide_index().set_properties(**{'text-align': 'left'}))"
+    "    df.style.set_properties(**{\"text-align\": \"right\"})\n",
+    "    display(df.style.hide_index().set_properties(**{\"text-align\": \"left\"}))"
    ]
   },
   {
@@ -367,13 +375,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "commands = ['osqueryi --logger_min_status 1 --json \"SELECT * FROM users JOIN user_ssh_keys USING (uid);\"']\n",
+    "commands = [\n",
+    "    'osqueryi --logger_min_status 1 --json \"SELECT * FROM users JOIN user_ssh_keys USING (uid);\"'\n",
+    "]\n",
     "for command in commands:\n",
-    "    data = subprocess.check_output(commands, shell=True).decode('utf-8')\n",
+    "    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n",
     "    nested = json.loads(data)\n",
     "    df = pd.DataFrame(json_normalize(nested))\n",
-    "    df.style.set_properties(**{'text-align': 'right'})\n",
-    "    display(df.style.hide_index().set_properties(**{'text-align': 'left'}))"
+    "    df.style.set_properties(**{\"text-align\": \"right\"})\n",
+    "    display(df.style.hide_index().set_properties(**{\"text-align\": \"left\"}))"
    ]
   },
   {
@@ -392,13 +402,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "commands = ['osqueryi --logger_min_status 1 --json \"SELECT username, description FROM users ORDER BY username;\"']\n",
+    "commands = [\n",
+    "    'osqueryi --logger_min_status 1 --json \"SELECT username, description FROM users ORDER BY username;\"'\n",
+    "]\n",
     "for command in commands:\n",
-    "    data = subprocess.check_output(commands, shell=True).decode('utf-8')\n",
+    "    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n",
     "    nested = json.loads(data)\n",
     "    df = pd.DataFrame(json_normalize(nested)).head(50)\n",
-    "    df.style.set_properties(**{'text-align': 'right'})\n",
-    "    display(df.style.hide_index().set_properties(**{'text-align': 'left'}))"
+    "    df.style.set_properties(**{\"text-align\": \"right\"})\n",
+    "    display(df.style.hide_index().set_properties(**{\"text-align\": \"left\"}))"
    ]
   }
  ],

--- a/OSQuery-Jupyter-MacOS.ipynb
+++ b/OSQuery-Jupyter-MacOS.ipynb
@@ -127,7 +127,7 @@
     ]
    },
    "outputs": [],
-   "source": "query = (\n    \"select bundle_identifier, bundle_short_version \"\n    \"from apps ORDER BY name;\"\n)\ncommands = [f'osqueryi --logger_min_status 1 --json \"{query}\"']\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested)).head(50)\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
+   "source": "# pylint: disable=line-too-long\n# flake8: noqa: E501\ncommands = [\n    'osqueryi --logger_min_status 1 --json \"select bundle_identifier, bundle_short_version from apps ORDER BY name;\"'\n]\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested)).head(50)\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
   },
   {
    "cell_type": "markdown",
@@ -148,7 +148,7 @@
     ]
    },
    "outputs": [],
-   "source": "query = \"select * from logged_in_users;\"\ncommands = [f'osqueryi --logger_min_status 1 --json \"{query}\"']\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested))\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
+   "source": "# pylint: disable=line-too-long\ncommands = [\n    'osqueryi --logger_min_status 1 --json \"select * from logged_in_users;\"'\n]\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested))\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
   },
   {
    "cell_type": "markdown",
@@ -194,7 +194,7 @@
     ]
    },
    "outputs": [],
-   "source": "query = \"SELECT network_name, security_type FROM wifi_networks;\"\ncommands = [f'osqueryi --logger_min_status 1 --json \"{query}\"']\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested)).head(50)\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
+   "source": "# pylint: disable=line-too-long\ncommands = [\n    'osqueryi --logger_min_status 1 --json \"SELECT network_name, security_type FROM wifi_networks;\"'\n]\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested)).head(50)\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
   },
   {
    "cell_type": "markdown",

--- a/OSQuery-Jupyter-MacOS.ipynb
+++ b/OSQuery-Jupyter-MacOS.ipynb
@@ -127,7 +127,7 @@
     ]
    },
    "outputs": [],
-   "source": "commands = [\n    'osqueryi --logger_min_status 1 --json '\n    '\"select bundle_identifier, bundle_short_version from apps ORDER BY name;\"'\n]\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested)).head(50)\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
+   "source": "commands = [\n    (\n        'osqueryi --logger_min_status 1 --json '\n        '\"select bundle_identifier, bundle_short_version '\n        'from apps ORDER BY name;\"'\n    )\n]\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested)).head(50)\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
   },
   {
    "cell_type": "markdown",
@@ -148,7 +148,7 @@
     ]
    },
    "outputs": [],
-   "source": "commands = [\n    'osqueryi --logger_min_status 1 --json '\n    '\"select * from logged_in_users;\"'\n]\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested))\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
+   "source": "commands = [\n    (\n        'osqueryi --logger_min_status 1 --json '\n        '\"select * from logged_in_users;\"'\n    )\n]\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested))\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
   },
   {
    "cell_type": "markdown",
@@ -194,7 +194,7 @@
     ]
    },
    "outputs": [],
-   "source": "commands = [\n    'osqueryi --logger_min_status 1 --json '\n    '\"SELECT network_name, security_type FROM wifi_networks;\"'\n]\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested)).head(50)\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
+   "source": "commands = [\n    (\n        'osqueryi --logger_min_status 1 --json '\n        '\"SELECT network_name, security_type FROM wifi_networks;\"'\n    )\n]\nfor command in commands:\n    data = subprocess.check_output(commands, shell=True).decode(\"utf-8\")\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested)).head(50)\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    display(df.style.hide_index())"
   },
   {
    "cell_type": "markdown",

--- a/OSQuery-Jupyter-Windows.ipynb
+++ b/OSQuery-Jupyter-Windows.ipynb
@@ -170,18 +170,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "def osquery_run(query):\n",
-    "    os.chdir(osquery_binary)\n",
-    "    data = subprocess.run(\n",
-    "        [\"osqueryi\", \"--json\", query], stdout=subprocess.PIPE, universal_newlines=True\n",
-    "    )\n",
-    "    data = data.stdout\n",
-    "    nested = json.loads(data)\n",
-    "    df = pd.DataFrame(json_normalize(nested))\n",
-    "    df.style.set_properties(**{\"text-align\": \"right\"})\n",
-    "    return df.style.hide_index()"
-   ]
+   "source": "def osquery_run(query):\n    \"\"\"Run an osquery command and return formatted DataFrame.\"\"\"\n    os.chdir(osquery_binary)\n    data = subprocess.run(\n        [\"osqueryi\", \"--json\", query],\n        stdout=subprocess.PIPE,\n        universal_newlines=True,\n        check=False,\n    )\n    data = data.stdout\n    nested = json.loads(data)\n    df = pd.DataFrame(json_normalize(nested))\n    df.style.set_properties(**{\"text-align\": \"right\"})\n    return df.style.hide_index()"
   },
   {
    "cell_type": "markdown",
@@ -286,11 +275,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "commands = \"SELECT a.interface, a.address, d.mac FROM interface_addresses a JOIN interface_details d USING (interface);\"\n",
-    "result_query = osquery_run(commands)\n",
-    "result_query"
-   ]
+   "source": "commands = (\n    \"SELECT a.interface, a.address, d.mac \"\n    \"FROM interface_addresses a \"\n    \"JOIN interface_details d USING (interface);\"\n)\nresult_query = osquery_run(commands)\nresult_query"
   },
   {
    "cell_type": "markdown",

--- a/OSQuery-Jupyter-Windows.ipynb
+++ b/OSQuery-Jupyter-Windows.ipynb
@@ -57,15 +57,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import json\n",
-    "import os\n",
-    "import subprocess\n",
-    "\n",
-    "import pandas as pd\n",
-    "import requests\n",
-    "from pandas import json_normalize"
-   ]
+   "source": "# pylint: disable=invalid-name,missing-module-docstring,missing-function-docstring\n# pylint: disable=pointless-statement,consider-using-with\nimport json\nimport os\nimport subprocess\n\nimport pandas as pd\nimport requests\nfrom pandas import json_normalize"
   },
   {
    "cell_type": "markdown",
@@ -141,13 +133,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "First we need to find location of Osquery on this system, as in Windows it does not set Osquery binary in the `PATH`.  \n",
-    "\n",
-    "Below only needs to be run once, it takes a few seconds to come back. If Osquery is installed on another partition than `C:\\` you will need to change `path` variable.  \n",
-    "\n",
-    "When you get result you can just put the value in the variable `osquery_binary`, if you do not mind the seconds it takes to find the binary you can run the code below everytime."
-   ]
+   "source": "First we need to find location of Osquery on this system, as in Windows it does not set\nOsquery binary in the `PATH`.\n\nBelow only needs to be run once, it takes a few seconds to come back. If Osquery is installed\non another partition than `C:\\` you will need to change `path` variable.\n\nWhen you get result you can just put the value in the variable `osquery_binary`, if you do\nnot mind the seconds it takes to find the binary you can run the code below everytime."
   },
   {
    "cell_type": "code",

--- a/OSQuery-Jupyter-Windows.ipynb
+++ b/OSQuery-Jupyter-Windows.ipynb
@@ -77,18 +77,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "version = \"4.3.0\"\n",
-    "url = f\"https://pkg.osquery.io/windows/osquery-{version}.msi\"\n",
-    "\n",
-    "# First find name of file to be used for installing\n",
-    "if url.find(\"/\"):\n",
-    "    osquery_filename = url.rsplit(\"/\", 1)[1]\n",
-    "\n",
-    "# Download file to current location\n",
-    "r = requests.get(url, allow_redirects=True)\n",
-    "open(osquery_filename, \"wb\").write(r.content)"
-   ]
+   "source": "version = \"4.3.0\"\nurl = f\"https://pkg.osquery.io/windows/osquery-{version}.msi\"\n\n# First find name of file to be used for installing\nif \"/\" in url:\n    osquery_filename = url.rsplit(\"/\", 1)[1]\nelse:\n    osquery_filename = f\"osquery-{version}.msi\"\n\n# Download file to current location\nr = requests.get(url, allow_redirects=True)\nopen(osquery_filename, \"wb\").write(r.content)"
   },
   {
    "cell_type": "markdown",
@@ -140,14 +129,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "%%time\n",
-    "path = \"c:\\\\\"\n",
-    "name = \"osqueryi.exe\"\n",
-    "for root, dirs, files in os.walk(path):\n",
-    "    if name in files:\n",
-    "        osquery_binary = os.path.join(root)"
-   ]
+   "source": "%%time\npath = \"c:\\\\\"\nname = \"osqueryi.exe\"\nosquery_binary = None\nfor root, dirs, files in os.walk(path):\n    if name in files:\n        osquery_binary = os.path.join(root)\n        break\nif osquery_binary is None:\n    print(f\"Warning: {name} not found in {path}\")"
   },
   {
    "cell_type": "code",

--- a/OSQuery-Jupyter-Windows.ipynb
+++ b/OSQuery-Jupyter-Windows.ipynb
@@ -58,13 +58,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
     "import json\n",
+    "import os\n",
     "import subprocess\n",
+    "\n",
     "import pandas as pd\n",
-    "from pandas import json_normalize\n",
-    "from IPython.display import JSON,display,HTML\n",
-    "import requests"
+    "import requests\n",
+    "from pandas import json_normalize"
    ]
   },
   {
@@ -87,15 +87,15 @@
    "outputs": [],
    "source": [
     "version = \"4.3.0\"\n",
-    "url = f'https://pkg.osquery.io/windows/osquery-{version}.msi'\n",
+    "url = f\"https://pkg.osquery.io/windows/osquery-{version}.msi\"\n",
     "\n",
-    "#First find name of file to be used for installing\n",
-    "if url.find('/'):\n",
-    "  osquery_filename = url.rsplit('/', 1)[1]\n",
+    "# First find name of file to be used for installing\n",
+    "if url.find(\"/\"):\n",
+    "    osquery_filename = url.rsplit(\"/\", 1)[1]\n",
     "\n",
-    "#Download file to current location\n",
+    "# Download file to current location\n",
     "r = requests.get(url, allow_redirects=True)\n",
-    "open(osquery_filename, 'wb').write(r.content)"
+    "open(osquery_filename, \"wb\").write(r.content)"
    ]
   },
   {
@@ -158,7 +158,7 @@
     "%%time\n",
     "path = \"c:\\\\\"\n",
     "name = \"osqueryi.exe\"\n",
-    "for (root, dirs, files) in os.walk(path):\n",
+    "for root, dirs, files in os.walk(path):\n",
     "    if name in files:\n",
     "        osquery_binary = os.path.join(root)"
    ]
@@ -187,11 +187,13 @@
    "source": [
     "def osquery_run(query):\n",
     "    os.chdir(osquery_binary)\n",
-    "    data = subprocess.run(['osqueryi', '--json', query], stdout=subprocess.PIPE, universal_newlines=True)\n",
+    "    data = subprocess.run(\n",
+    "        [\"osqueryi\", \"--json\", query], stdout=subprocess.PIPE, universal_newlines=True\n",
+    "    )\n",
     "    data = data.stdout\n",
     "    nested = json.loads(data)\n",
     "    df = pd.DataFrame(json_normalize(nested))\n",
-    "    df.style.set_properties(**{'text-align': 'right'})\n",
+    "    df.style.set_properties(**{\"text-align\": \"right\"})\n",
     "    return df.style.hide_index()"
    ]
   },
@@ -341,7 +343,7 @@
     "commands = \"SELECT device_id, description, file_system, size, boot_partition FROM logical_drives;\"\n",
     "result_query = osquery_run(commands)\n",
     "result_query\n",
-    "#display(df.style.hide_index().set_properties(**{'text-align': 'left'}))"
+    "# display(df.style.hide_index().set_properties(**{'text-align': 'left'}))"
    ]
   },
   {

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Osquery-Jupyter
+
 Jupyter Notebooks for learning Osquery.  
 Current Operating System Notebooks:
+
 - MacOS
 - Windows
 
 Todo:
+
 - Linux


### PR DESCRIPTION
## Summary

Updates all GitHub Actions to their latest major versions and ensures Dependabot is configured to keep them current.

### Why
Node.js 20 actions are deprecated and will be forced to Node.js 24 starting June 2, 2026.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>